### PR TITLE
The smoke_test_results were broken.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -7,7 +7,7 @@ Best way to install Capistrano Slack intergration is via Bundler.
 Add the following to your Gemfile, then run the `bundle` command to install the gem direct from the git repository
 
 ```
-gem 'capistrano-slack', git: 'https://github.com/mike-ball/capistrano-slack'
+gem 'capistrano-slack', git: 'https://github.com/nextupdate/capistrano-slack'
 ```
 
 Once installed you can use the settings below in your Capistrano deploy.rb to configure Slack.

--- a/README.markdown
+++ b/README.markdown
@@ -7,7 +7,7 @@ Best way to install Capistrano Slack intergration is via Bundler.
 Add the following to your Gemfile, then run the `bundle` command to install the gem direct from the git repository
 
 ```
-gem 'capistrano-slack', :git => 'https://github.com/nextupdate/capistrano-slack.git'
+gem 'capistrano-slack', git: 'https://github.com/mike-ball/capistrano-slack'
 ```
 
 Once installed you can use the settings below in your Capistrano deploy.rb to configure Slack.

--- a/lib/capistrano/slack.rb
+++ b/lib/capistrano/slack.rb
@@ -110,7 +110,7 @@ module Capistrano
         status_code = `curl#{basic_auth_option} -s -w "%{http_code}" "#{url}" -o /dev/null`
 
         # Let's turn the status code into a friendly message
-        if status_code == expected_status_code
+        if status_code.to_s == expected_status_code.to_s
           color = 'good'
           result_message = "Passed with status code #{status_code}"
         else
@@ -124,7 +124,7 @@ module Capistrano
           "fields" => [
             {
               "title" => "#{name}",
-              "value" => "<#{url}>",
+              "value" => "#{url}",
               "short" => false
             },
             {

--- a/lib/capistrano/slack.rb
+++ b/lib/capistrano/slack.rb
@@ -107,7 +107,7 @@ module Capistrano
         expected_status_code = site[:expected_status_code]
 
         # Test the site and get a pass/fail value
-        status_code = `curl#{basic_auth_option} -s -w "%{http_code}" https://nextupdate.#{domain}/login -o /dev/null`
+        status_code = `curl#{basic_auth_option} -s -w "%{http_code}" "#{url}" -o /dev/null`
 
         # Let's turn the status code into a friendly message
         if status_code == expected_status_code


### PR DESCRIPTION
The URL for all smoke tests was hard coded to:
https://nextupdate.#{domain}/login

It was ignoring any endpoints defined in the deploy.rb file. This was a direct contradiction of the documentation. I fixed the implementation so endpoints and smoke_test_urls function as the documentation specifies.

``` ruby
endpoints = [
  {
    name: "Public",
    url: "https://#{domain}"
  },
  {
    name: "Application",
    url: "https://#{domain}/login",
    expected_status_code: 404
  }
]
```
