### PR TITLE
Added ability to set webhook url directly 

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -24,6 +24,7 @@ set :slack_room, "#general" # the room to send the message to
 set :slack_subdomain, "example" # if your subdomain is example.slack.com
 
 # optional
+set :slack_webhook_url, "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX" # overides the  specified token and subdomain to use the specified webhook url.
 set :slack_application, "Application Name" # override Capistrano `application`
 set :slack_username, "Deploy Bot" # displayed as name of message sender
 set :slack_emoji, ":cloud:" # will be used as the avatar for the message

--- a/lib/capistrano/slack.rb
+++ b/lib/capistrano/slack.rb
@@ -21,7 +21,7 @@ module Capistrano
         namespace :slack do
 
           task :starting do
-            return if slack_token.nil?
+            return if slack_token.nil? and slack_webhook_url.nil?
 
             announcement = "#{announced_deployer} is deploying #{announced_application_name} to #{announced_stage}"
 
@@ -31,7 +31,7 @@ module Capistrano
           end
 
           task :finished do
-            return if slack_token.nil?
+            return if slack_token.nil? and slack_webhook_url.nil?
             end_time = Time.now
             start_time = fetch(:start_time)
             elapsed = end_time.to_i - start_time.to_i
@@ -68,7 +68,11 @@ module Capistrano
 
     def post_slack_message(message, attachments=[])
       # Parse the API url and create an SSL connection
-      uri = URI.parse("https://#{slack_subdomain}.slack.com/services/hooks/incoming-webhook?token=#{slack_token}")
+      if slack_webhook_url.nil?
+        uri = URI.parse("https://#{slack_subdomain}.slack.com/services/hooks/incoming-webhook?token=#{slack_token}")
+      else
+        uri = URI.parse(slack_webhook_url)
+      end
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true
       http.verify_mode = OpenSSL::SSL::VERIFY_NONE


### PR DESCRIPTION
Added ability to set webhook url directly since Slack's webhook integration page no longer give you a toke, but a full webhook url. (Sorry for the double pull request)
